### PR TITLE
Mock http with nock in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "tape": "1.x",
-    "mock": "0.1.x",
-    "sinon": "~1.9"
+    "nock": "~0.27.2"
   }
 }

--- a/tests.js
+++ b/tests.js
@@ -1,159 +1,153 @@
-var test = require('tape')
-  , mock = require('mock')
-  , sinon = require('sinon')
-  , request = require('request')
-  , nop = function() {}
-  , requestMock = nop;
-
-var requestModule = function() {
-  return requestMock.apply(null, arguments);
-};
-requestModule.initParams = request.initParams;
-
-var Yammer = mock('./lib/yammer', {
-    request: requestModule
-  }, require);
-
+var test = require('tape');
+var nock = require('nock');
+var Yammer = require('./lib/yammer');
 
 test('access_token is added as authorization header', function(t) {
-  requestMock = sinon.spy();
+  var yam = new Yammer({ access_token: 'test_token' });
 
-  var yam = new Yammer({
-    access_token: 'test_token'
-  });
+  nock('https://www.yammer.dev').get('/test.json')
+    .reply(200, {});
 
   yam.request({
-    uri: '/test'
-  }, nop);
-
-  t.ok(requestMock.calledWithMatch('/test', {
-    headers: {
-      authorization: 'Bearer test_token'
-    }
-  }), 'oauth token present in headers');
-
-  return t.end();
+    uri: 'https://www.yammer.dev/test'
+  }, function (err, body, res) {
+    t.equal(res.request.headers.authorization, 'Bearer test_token',
+      'oauth token present in headers');
+    t.end();
+  });
 });
 
-test('json format is added by default', function(t) {
-  requestMock = sinon.spy();
 
+test('json format is added by default', function(t) {
   var yam = new Yammer();
 
+  nock('https://www.yammer.dev').get('/test.json')
+    .reply(200, {});
+
   yam.request({
-    uri: '/test'
-  }, nop);
+    uri: 'https://www.yammer.dev/test'
+  }, function (err, body, res) {
+    t.equal(res.request.uri.path, '/test.json', 'url has json format');
+    t.end();
+  });
+});
 
-  t.ok(requestMock.calledWithMatch('/test.json'), 'url has json format');
 
-  return t.end();
+test('json response is parsed automatically', function(t) {
+  var yam = new Yammer();
+
+  nock('https://www.yammer.dev').get('/test.json')
+    .reply(200, { test: "json" });
+
+  yam.request({
+    uri: 'https://www.yammer.dev/test'
+  }, function (err, body, res) {
+    t.deepEqual(body, { test: 'json' }, 'json response is parsed');
+    t.end();
+  });
 });
 
 
 test('400 response returns error', function(t) {
-  requestMock = sinon.stub().callsArgWith(2
-    , null
-    , {
-      statusCode: 404
-    }
-    , '');
-
-  var spy = sinon.spy()
-  , yam = new Yammer();
-
-  yam.request({
-    uri: '/test.json'
-  }, spy);
-
-  t.ok(spy.calledWithMatch(Error), 'error on 400 response');
-  return t.end();
-});
-
-test('500 response returns error', function(t) {
-  requestMock = sinon.stub().callsArgWith(2
-    , null
-    , {
-      statusCode: 500
-    }
-    , '');
-
-  var spy = sinon.spy()
-  , yam = new Yammer();
-
-  yam.request({
-    uri: '/test.json'
-  }, spy);
-
-  t.ok(spy.calledWithMatch(Error), 'error on 500 response');
-  return t.end();
-});
-
-test('boolean callbacks return false for 404', function(t) {
-  requestMock = sinon.stub().callsArgWith(2
-    , null
-    , {
-      statusCode: 404
-    }
-    , '');
-
-  var spy = sinon.spy()
-  , yam = new Yammer();
-
-  yam.checkUserSubscription('id', spy);
-
-  t.ok(spy.calledWith(null, false), 'checkUserSubscription boolean');
-
-  yam.checkTagSubscription('id', spy);
-
-  t.ok(spy.calledWith(null, false), 'checkTagSubscription boolean');
-
-  yam.checkThreadSubscription('id', spy);
-
-  t.ok(spy.calledWith(null, false), 'checkThreadSubscription boolean');
-
-  yam.checkTopicSubscription('id', spy);
-
-  t.ok(spy.calledWith(null, false), 'checkTopicSubscription boolean');
-
-  return t.end();
-});
-
-test('qs property is passed through as query parameters', function(t) {
-  requestMock = sinon.spy();
-
   var yam = new Yammer();
 
-  yam.request({
-    uri: '/test'
-    , qs: {
-      test_prop: "test_value"
-    }
-  }, nop);
+  nock('https://www.yammer.dev/').get('/test.json')
+    .reply(404, '');
 
-  t.ok(requestMock.calledWithMatch('/test', {
+  yam.request({
+    uri: 'https://www.yammer.dev/test'
+  }, function (err, body, res) {
+    t.ok(err instanceof Error, 'error on 400 response');
+    t.end();
+  });
+});
+
+
+test('500 response returns error', function(t) {
+  var yam = new Yammer();
+
+  nock('https://www.yammer.dev').get('/test.json')
+    .reply(500, '')
+
+  yam.request({
+    uri: 'htps://www.yammer.dev/test'
+  }, function (err, body, res) {
+    t.ok(err instanceof Error, 'error on 500 response');
+    t.end();
+  });
+});
+
+
+test('boolean callbacks return false for 404', function(t) {
+  var yam = new Yammer({
+    hostname: 'https://www.yammer.dev'
+  });
+
+  t.plan(4);
+
+  nock('https://www.yammer.dev').get('/api/v1/subscriptions/to_user/1.json')
+    .reply(404, '');
+
+  yam.checkUserSubscription(1, function (err, body) {
+    t.equal(body, false, 'checkUserSubscription boolean');
+  });
+
+  nock('https://www.yammer.dev').get('/api/v1/subscriptions/to_tag/1.json')
+    .reply(404, '');
+
+  yam.checkTagSubscription(1, function (err, body) {
+    t.equal(body, false, 'checkTagSubscription boolean');
+  });
+
+  nock('https://www.yammer.dev').get('/api/v1/subscriptions/to_thread/1.json')
+    .reply(404, '');
+
+  yam.checkThreadSubscription(1, function (err, body) {
+    t.equal(body, false, 'checkThreadSubscription boolean');
+  });
+
+  nock('https://www.yammer.dev').get('/api/v1/subscriptions/to_topic/1.json')
+    .reply(404, '');
+
+  yam.checkTopicSubscription(1, function (err, body) {
+    t.equal(body, false, 'checkTopicSubscription boolean');
+  });
+});
+
+
+test('qs property is passed through as query parameters', function(t) {
+  var yam = new Yammer();
+
+  nock('https://www.yammer.dev').get('/test.json?test_prop=test_value')
+    .reply(200, '');
+
+  yam.request({
+    uri: 'https://www.yammer.dev/test',
     qs: {
       test_prop: 'test_value'
     }
-  }), 'yam.request sends query parameters');
-
-  return t.end();
+  }, function (err, body, res) {
+    t.equal(res.request.uri.query, 'test_prop=test_value',
+      'yam.request sends query parameters');
+    t.end();
+  });
 });
 
+
 test('form encoded data is sent', function(t) {
-  requestMock = sinon.spy();
+  var yam = new Yammer({ hostname: 'https://www.yammer.dev' });
 
-  var yam = new Yammer();
+  nock('https://www.yammer.dev').post('/api/v1/messages.json')
+    .reply(200, '');
 
-  yam.createMessage({ test_prop: 'test_value' }, nop);
+  yam.createMessage({ test_prop: 'test_value' }, function (err, body, res) {
+    var req = res.request;
+    t.equal(req.headers['content-type'],
+      'application/x-www-form-urlencoded; charset=utf-8',
+      'content-type set correctly');
+    t.equal(String(req.body), 'test_prop=test_value',
+      'request body sent');
+    t.end();
+  });
 
-  t.ok(requestMock.calledWithMatch('/api/v1/messages.json', {
-    headers: {
-      'content-type': 'application/x-www-form-urlencoded'
-    }
-    , form: {
-      test_prop: 'test_value'
-    }
-  }), 'yam.request sends query parameters');
-
-  return t.end();
 });


### PR DESCRIPTION
Switch from mocking `request` with `mock` to mocking the underlying HTTP requests with `nock`. Longer term this should make it easier to test against API response fixtures.
