### PR TITLE
Split endpoint groups into separate modules

### DIFF
--- a/lib/groups.js
+++ b/lib/groups.js
@@ -1,0 +1,14 @@
+function Groups(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+}
+
+module.exports = Groups;
+
+Groups.prototype.all = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/groups', opts, cb);
+};
+
+Groups.prototype.byId = function (id, opts, cb) {
+  this.request(this.hostname + '/api/v1/groups/'+id, opts, cb);
+};

--- a/lib/invitations.js
+++ b/lib/invitations.js
@@ -1,0 +1,16 @@
+var initParams = require('request').initParams;
+
+function Invitations(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this._formpost = yammer._formpost.bind(yammer);
+}
+
+module.exports = Invitations;
+
+Invitations.prototype.invite = function (formdata, opts, cb) {
+  var args = initParams(this.hostname + '/api/v1/invitations'
+    , opts, cb);
+
+  args.options.form = formdata;
+  this._formpost(args.uri, args.options, args.callback);
+};

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,0 +1,83 @@
+var initParams = require('request').initParams;
+
+function Messages(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+  this._formpost = yammer._formpost.bind(yammer);
+}
+
+module.exports = Messages;
+
+Messages.prototype.all = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/messages', opts, cb);
+};
+
+Messages.prototype.sent = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/sent', opts, cb);
+};
+
+Messages.prototype.received = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/received', opts, cb);
+};
+
+Messages.prototype.following = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/following', opts, cb);
+};
+
+Messages.prototype.fromUser = function (userid, opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/from_user/'+userid, opts, cb);
+};
+
+Messages.prototype.fromBot = function (botid, opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/bot_user/'+botid, opts, cb);
+};
+
+Messages.prototype.withTag = function (tagid, opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/tagged_with/'+tagid, opts, cb);
+};
+
+Messages.prototype.inGroup = function (groupid, opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/in_group/'+groupid, opts, cb);
+};
+
+Messages.prototype.favoritesOf = function (userid, opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/favorites_of/'+userid, opts, cb);
+};
+
+Messages.prototype.likedBy = function (userid, opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/liked_by/'+userid, opts, cb);
+};
+
+Messages.prototype.inThread = function (threadid, opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/in_thread/'+threadid, opts, cb);
+};
+
+Messages.prototype.aboutTopic = function (id, opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/about_topic/'+id, opts, cb);
+};
+
+Messages.prototype.private = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/private', opts, cb);
+};
+
+Messages.prototype.direct = Messages.prototype.private;
+
+Messages.prototype.inbox = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/messages/inbox', opts, cb);
+};
+
+Messages.prototype.post = function (formdata, opts, cb) {
+  var args = initParams(this.hostname + '/api/v1/messages'
+    , opts, cb);
+
+  args.options.form = formdata;
+  this._formpost(args.uri, args.options, args.callback);
+};
+
+Messages.prototype.like = function (formdata, opts, cb) {
+  var args = initParams(this.hostname + '/api/v1/messages/liked_by/current'
+    , opts, cb);
+
+  args.options.form = formdata;
+  this._formpost(args.uri, args.options, args.callback);
+};

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -1,0 +1,10 @@
+function Networks(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+}
+
+module.exports = Networks;
+
+Networks.prototype.current = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/networks/current', opts, cb);
+};

--- a/lib/presences.js
+++ b/lib/presences.js
@@ -1,0 +1,14 @@
+function Presences(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+}
+
+module.exports = Presences;
+
+Presences.prototype.all = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/presences', opts, cb);
+};
+
+Presences.prototype.byFollowing = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/presences/by_following', opts, cb);
+};

--- a/lib/realtime.js
+++ b/lib/realtime.js
@@ -1,0 +1,82 @@
+var request = require('request');
+
+function RealTime (yam) {
+  this.yam = yam;
+}
+
+module.exports = RealTime;
+
+RealTime.prototype.messages = function (cb) {
+  this.yam.messages.all(function (e, body) {
+    if (e) return cb(e);
+    var meta = body.meta.realtime
+      , id = 1
+      ;
+
+    request(
+      { url: meta.uri + 'handshake'
+      , headers: {'content-type':'application/json'}
+      , method: 'POST'
+      , body: JSON.stringify(
+        [ { ext: {"token": meta.authentication_token}
+          , version: "1.0"
+          , minimumVersion: "0.9"
+          , channel: "/meta/handshake"
+          , supportedConnectionTypes: ["long-polling","callback-polling"]
+          , id: id
+          }
+        ])
+      }, function (e, resp, b) {
+      if (e) return cb(e);
+      if (resp.statusCode !== 200) return cb(new Error('Status code is not 200\n'+b))
+      var handshake = JSON.parse(b)[0];
+      id += 1
+      request.post(
+        { url: meta.uri
+        , headers: {'content-type':'application/json'}
+        , body: JSON.stringify(
+          [ { channel: "/meta/subscribe"
+            , subscription: "/feeds/" + meta.channel_id + "/primary"
+            , id: id
+            , clientId: handshake.clientId
+            }
+          , { channel: "/meta/subscribe"
+            , subscription: "/feeds/" + meta.channel_id + "/secondary"
+            , id: id + 1
+            , clientId: handshake.clientId
+            }
+          ])
+        }, function (e, resp, b) {
+          if (e) return cb(e);
+          if (resp.statusCode !== 200) return cb(new Error('Status code is not 200\n'+b))
+          id += 1
+          var getchannel = function () {
+            id += 1
+            request.post(
+              { url: meta.uri + 'connect'
+              , headers: {'content-type': 'application/json'}
+              , body: JSON.stringify(
+                [ { channel: "/meta/connect"
+                  , connectionType: 'long-polling'
+                  , id: id
+                  , clientId: handshake.clientId
+                  }
+                ])
+              }, function (e, resp, b) {
+                if (e) return cb(e);
+                if (resp.statusCode !== 200) return cb(new Error('Status code is not 200\n'+b))
+                var b = JSON.parse(b);
+                b.pop()
+                b.forEach(function (r) {
+                  cb(null, r.data);
+                })
+                getchannel();
+              }
+            )
+          }
+          getchannel();
+        }
+      )
+    })
+  })
+};

--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -1,0 +1,10 @@
+function Relationships(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+}
+
+module.exports = Relationships;
+
+Relationships.prototype.all = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/relationships', opts, cb);
+};

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,0 +1,16 @@
+var initParams = require('request').initParams;
+
+function Search(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+}
+
+module.exports = Search;
+
+Search.prototype.query = function (params, opts, cb) {
+  var args = initParams(this.hostname + '/api/v1/search'
+    , opts, cb);
+
+  args.options.qs = params;
+  this.request(args.uri, args.options, args.callback);
+};

--- a/lib/subscriptions.js
+++ b/lib/subscriptions.js
@@ -1,0 +1,31 @@
+function Subscriptions(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+  this._boolCb = yammer._boolCb.bind(yammer);
+}
+
+module.exports = Subscriptions;
+
+Subscriptions.prototype.toUser = function (userid, opts, cb) {
+  var args = this._boolCb(this.hostname + '/api/v1/subscriptions/to_user/'+userid
+    , opts, cb);
+  this.request(args.uri, args.options, args.callback);
+};
+
+Subscriptions.prototype.toTag = function (tagid, opts, cb) {
+  var args = this._boolCb(this.hostname + '/api/v1/subscriptions/to_tag/'+tagid
+    , opts, cb);
+  this.request(args.uri, args.options, args.callback);
+};
+
+Subscriptions.prototype.toThread = function (threadid, opts, cb) {
+  var args = this._boolCb(this.hostname + '/api/v1/subscriptions/to_thread/'+threadid
+    , opts, cb);
+  this.request(args.uri, args.options, args.callback);
+};
+
+Subscriptions.prototype.toTopic = function (topicid, opts, cb) {
+  var args = this._boolCb(this.hostname + '/api/v1/subscriptions/to_topic/'+topicid
+    , opts, cb);
+  this.request(args.uri, args.options, args.callback);
+};

--- a/lib/suggestions.js
+++ b/lib/suggestions.js
@@ -1,0 +1,14 @@
+function Suggestions(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+}
+
+module.exports = Suggestions;
+
+Suggestions.prototype.all = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/suggestions', opts, cb);
+};
+
+Suggestions.prototype.users = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/suggestions/users', opts, cb);
+};

--- a/lib/threads.js
+++ b/lib/threads.js
@@ -1,0 +1,10 @@
+function Threads(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+}
+
+module.exports = Threads;
+
+Threads.prototype.byId = function (id, opts, cb) {
+  this.request(this.hostname + '/api/v1/threads/'+id, opts, cb);
+};

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,0 +1,10 @@
+function Tokens(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+}
+
+module.exports = Tokens;
+
+Tokens.prototype.all = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/oauth/tokens', opts, cb)
+};

--- a/lib/topics.js
+++ b/lib/topics.js
@@ -1,0 +1,10 @@
+function Topics(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+};
+
+module.exports = Topics;
+
+Topics.prototype.byId = function (id, opts, cb) {
+  this.request(this.hostname + '/api/v1/topics/'+id, opts, cb);
+};

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,0 +1,18 @@
+function Users(yammer) {
+  this.hostname = yammer.opts.hostname;
+  this.request = yammer.request.bind(yammer);
+};
+
+module.exports = Users;
+
+Users.prototype.all = function (opts, cb) {
+  this.request(this.hostname + '/api/v1/users', opts, cb);
+};
+
+Users.prototype.byId = function (id, opts, cb) {
+  this.request(this.hostname + '/api/v1/users/'+id, opts, cb);
+};
+
+Users.prototype.byEmail = function (email, opts, cb) {
+  this.request(this.hostname + '/api/v1/users/by_email.json?email='+encodeURIComponent(email), opts, cb);
+};

--- a/lib/yammer.js
+++ b/lib/yammer.js
@@ -4,84 +4,22 @@ var request = require('request')
 var slice = Array.prototype.slice
   , initParams = request.initParams;
 
+// Endpoint group submodules
+var Groups = require('./groups');
+var Invitations = require('./invitations');
+var Messages = require('./messages');
+var Networks = require('./networks');
+var Presences = require('./presences');
+var Realtime = require('./realtime');
+var Relationships = require('./relationships');
+var Search = require('./search');
+var Subscriptions = require('./subscriptions');
+var Suggestions = require('./suggestions');
+var Threads = require('./threads');
+var Tokens = require('./tokens');
+var Topics = require('./topics');
+var Users = require('./users');
 
-function RealTime (yam) {
-  this.yam = yam;
-}
-RealTime.prototype.messages = function (cb) {
-  this.yam.messages(function (e, body) {
-    if (e) return cb(e);
-    var meta = body.meta.realtime
-      , id = 1
-      ;
-
-    request(
-      { url: meta.uri + 'handshake'
-      , headers: {'content-type':'application/json'}
-      , method: 'POST'
-      , body: JSON.stringify(
-        [ { ext: {"token": meta.authentication_token}
-          , version: "1.0"
-          , minimumVersion: "0.9"
-          , channel: "/meta/handshake"
-          , supportedConnectionTypes: ["long-polling","callback-polling"]
-          , id: id
-          }
-        ])
-      }, function (e, resp, b) {
-      if (e) return cb(e);
-      if (resp.statusCode !== 200) return cb(new Error('Status code is not 200\n'+b))
-      var handshake = JSON.parse(b)[0];
-      id += 1
-      request.post(
-        { url: meta.uri
-        , headers: {'content-type':'application/json'}
-        , body: JSON.stringify(
-          [ { channel: "/meta/subscribe"
-            , subscription: "/feeds/" + meta.channel_id + "/primary"
-            , id: id
-            , clientId: handshake.clientId
-            }
-          , { channel: "/meta/subscribe"
-            , subscription: "/feeds/" + meta.channel_id + "/secondary"
-            , id: id + 1
-            , clientId: handshake.clientId
-            }
-          ])
-        }, function (e, resp, b) {
-          if (e) return cb(e);
-          if (resp.statusCode !== 200) return cb(new Error('Status code is not 200\n'+b))
-          id += 1
-          var getchannel = function () {
-            id += 1
-            request.post(
-              { url: meta.uri + 'connect'
-              , headers: {'content-type': 'application/json'}
-              , body: JSON.stringify(
-                [ { channel: "/meta/connect"
-                  , connectionType: 'long-polling'
-                  , id: id
-                  , clientId: handshake.clientId
-                  }
-                ])
-              }, function (e, resp, b) {
-                if (e) return cb(e);
-                if (resp.statusCode !== 200) return cb(new Error('Status code is not 200\n'+b))
-                var b = JSON.parse(b);
-                b.pop()
-                b.forEach(function (r) {
-                  cb(null, r.data);
-                })
-                getchannel();
-              }
-            )
-          }
-          getchannel();
-        }
-      )
-    })
-  })
-}
 
 function Yammer (opts) {
 
@@ -92,8 +30,24 @@ function Yammer (opts) {
   this.opts = mixin({
     hostname: 'https://www.yammer.com'
   }, opts);
-  this.realtime = new RealTime(this);
+
+  // Initialise each of the sub-apis.
+  this.groups = new Groups(this);
+  this.invitations = new Invitations(this);
+  this.messages = new Messages(this);
+  this.networks = new Networks(this);
+  this.presences = new Presences(this);
+  this.realtime = new Realtime(this);
+  this.relationships = new Relationships(this);
+  this.search = new Search(this);
+  this.subscriptions = new Subscriptions(this);
+  this.suggestions = new Suggestions(this);
+  this.threads = new Threads(this);
+  this.tokens = new Tokens(this);
+  this.topics = new Topics(this);
+  this.users = new Users(this);
 }
+
 Yammer.prototype.request = function (uri, opts, cb) {
   var args = initParams(uri, opts, cb);
 
@@ -125,13 +79,14 @@ Yammer.prototype.request = function (uri, opts, cb) {
 
     return cb(null, body, resp);
   });
-}
+};
 
 function formError(name, cb) {
   return process.nextTick(function() {
     return cb(new Error(name + ' requires form data'));
   });
 }
+
 Yammer.prototype._formpost = function (url, opts, cb) {
   var headers = opts.headers || {};
   headers['content-type'] = 'application/x-www-form-urlencoded';
@@ -140,7 +95,8 @@ Yammer.prototype._formpost = function (url, opts, cb) {
   opts.method = 'POST';
 
   this.request(url, opts, cb);
-}
+};
+
 Yammer.prototype._boolCb = function(uri, opts, cb) {
   var ret = {}
     , args = initParams(uri, opts, cb);
@@ -159,153 +115,6 @@ Yammer.prototype._boolCb = function(uri, opts, cb) {
       return cb(null, body);
     }
   }
-}
-Yammer.prototype.messages = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages', opts, cb);
-}
-Yammer.prototype.messagesSent = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/sent', opts, cb);
-}
-Yammer.prototype.messagesReceived = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/received', opts, cb);
-}
-Yammer.prototype.messagesFollowing = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/following', opts, cb);
-}
-Yammer.prototype.messagesFromUser = function (userid, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/from_user/'+userid, opts, cb);
-}
-Yammer.prototype.messagesFromBot = function (botid, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/bot_user/'+botid, opts, cb);
-}
-Yammer.prototype.messagesWithTag = function (tagid, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/tagged_with/'+tagid, opts, cb);
-}
-Yammer.prototype.messagesInGroup = function (groupid, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/in_group/'+groupid, opts, cb);
-}
-Yammer.prototype.messagesFavoritesOf = function (userid, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/favorites_of/'+userid, opts, cb);
-}
-Yammer.prototype.messagesLikedBy = function (userid, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/liked_by/'+userid, opts, cb);
-}
-Yammer.prototype.messagesInThread = function (threadid, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/in_thread/'+threadid, opts, cb);
-}
-Yammer.prototype.messagesAboutTopic = function (id, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/about_topic/'+id, opts, cb);
-}
-Yammer.prototype.messagesPrivate = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/private', opts, cb);
-}
-Yammer.prototype.directMessages = Yammer.prototype.messagesPrivate;
-
-Yammer.prototype.messagesInbox = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/messages/inbox', opts, cb);
-}
-
-Yammer.prototype.groups = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/groups', opts, cb);
-}
-Yammer.prototype.group = function (id, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/groups/'+id, opts, cb);
-}
-
-Yammer.prototype.topic = function (id, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/topics/'+id, opts, cb);
-}
-
-Yammer.prototype.users = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/users', opts, cb);
-}
-Yammer.prototype.user = function (id, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/users/'+id, opts, cb);
-}
-Yammer.prototype.userByEmail = function (email, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/users/by_email.json?email='+encodeURIComponent(email), opts, cb);
-}
-
-Yammer.prototype.relationships = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/relationships', opts, cb);
-}
-
-Yammer.prototype.suggestions = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/suggestions', opts, cb);
-}
-Yammer.prototype.suggestedUsers = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/suggestions/users', opts, cb);
-}
-
-Yammer.prototype.thread = function (id, opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/threads/'+id, opts, cb);
-}
-
-
-Yammer.prototype.checkUserSubscription = function (userid, opts, cb) {
-  var args = this._boolCb(this.opts.hostname + '/api/v1/subscriptions/to_user/'+userid
-    , opts, cb);
-  this.request(args.uri, args.options, args.callback);
-}
-Yammer.prototype.checkTagSubscription = function (tagid, opts, cb) {
-  var args = this._boolCb(this.opts.hostname + '/api/v1/subscriptions/to_tag/'+tagid
-    , opts, cb);
-  this.request(args.uri, args.options, args.callback);
-}
-Yammer.prototype.checkThreadSubscription = function (threadid, opts, cb) {
-  var args = this._boolCb(this.opts.hostname + '/api/v1/subscriptions/to_thread/'+threadid
-    , opts, cb);
-  this.request(args.uri, args.options, args.callback);
-}
-Yammer.prototype.checkTopicSubscription = function (topicid, opts, cb) {
-  var args = this._boolCb(this.opts.hostname + '/api/v1/subscriptions/to_topic/'+topicid
-    , opts, cb);
-  this.request(args.uri, args.options, args.callback);
-}
-
-Yammer.prototype.search = function (params, opts, cb) {
-  var args = initParams(this.opts.hostname + '/api/v1/search'
-    , opts, cb);
-
-  args.options.qs = params;
-  this.request(args.uri, args.options, args.callback);
-}
-
-Yammer.prototype.networks = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/networks/current', opts, cb);
-}
-
-Yammer.prototype.invite = function (formdata, opts, cb) {
-  var args = initParams(this.opts.hostname + '/api/v1/invitations'
-    , opts, cb);
-
-  args.options.form = formdata;
-  this._formpost(args.uri, args.options, args.callback);
-}
-Yammer.prototype.createMessage = function (formdata, opts, cb) {
-  var args = initParams(this.opts.hostname + '/api/v1/messages'
-    , opts, cb);
-
-  args.options.form = formdata;
-  this._formpost(args.uri, args.options, args.callback);
-}
-Yammer.prototype.likeMessage = function(formdata, opts, cb) {
-  var args = initParams(this.opts.hostname + '/api/v1/messages/liked_by/current'
-    , opts, cb);
-
-  args.options.form = formdata;
-  this._formpost(args.uri, args.options, args.callback);
-}
-
-Yammer.prototype.presences = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/presences', opts, cb);
-}
-Yammer.prototype.presencesByFollowing = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/presences/by_following', opts, cb);
-}
-
-Yammer.prototype.tokens = function (opts, cb) {
-  this.request(this.opts.hostname + '/api/v1/oauth/tokens', opts, cb)
-}
+};
 
 module.exports = Yammer;

--- a/tests.js
+++ b/tests.js
@@ -88,29 +88,29 @@ test('boolean callbacks return false for 404', function(t) {
   nock('https://www.yammer.dev').get('/api/v1/subscriptions/to_user/1.json')
     .reply(404, '');
 
-  yam.checkUserSubscription(1, function (err, body) {
-    t.equal(body, false, 'checkUserSubscription boolean');
+  yam.subscriptions.toUser(1, function (err, body) {
+    t.equal(body, false, 'subscriptions.toUser boolean');
   });
 
   nock('https://www.yammer.dev').get('/api/v1/subscriptions/to_tag/1.json')
     .reply(404, '');
 
-  yam.checkTagSubscription(1, function (err, body) {
-    t.equal(body, false, 'checkTagSubscription boolean');
+  yam.subscriptions.toTag(1, function (err, body) {
+    t.equal(body, false, 'subscriptions.toTag boolean');
   });
 
   nock('https://www.yammer.dev').get('/api/v1/subscriptions/to_thread/1.json')
     .reply(404, '');
 
-  yam.checkThreadSubscription(1, function (err, body) {
-    t.equal(body, false, 'checkThreadSubscription boolean');
+  yam.subscriptions.toThread(1, function (err, body) {
+    t.equal(body, false, 'subscriptions.toThread boolean');
   });
 
   nock('https://www.yammer.dev').get('/api/v1/subscriptions/to_topic/1.json')
     .reply(404, '');
 
-  yam.checkTopicSubscription(1, function (err, body) {
-    t.equal(body, false, 'checkTopicSubscription boolean');
+  yam.subscriptions.toTopic(1, function (err, body) {
+    t.equal(body, false, 'subscriptions.toTopic boolean');
   });
 });
 
@@ -140,7 +140,7 @@ test('form encoded data is sent', function(t) {
   nock('https://www.yammer.dev').post('/api/v1/messages.json')
     .reply(200, '');
 
-  yam.createMessage({ test_prop: 'test_value' }, function (err, body, res) {
+  yam.messages.post({ test_prop: 'test_value' }, function (err, body, res) {
     var req = res.request;
     t.equal(req.headers['content-type'],
       'application/x-www-form-urlencoded; charset=utf-8',
@@ -149,5 +149,4 @@ test('form encoded data is sent', function(t) {
       'request body sent');
     t.end();
   });
-
 });


### PR DESCRIPTION
Each endpoint group (e.g. messages, users) is split into it's own module, which exports a constructor. The Yammer object now simply provides a method of communicating generically with the API, while the
modules control the particulars of each endpoint.
